### PR TITLE
Store repost ParentPostHashHex on txindex metadata.

### DIFF
--- a/consumer/helpers.go
+++ b/consumer/helpers.go
@@ -490,9 +490,7 @@ func ComputeTransactionMetadata(txn *lib.MsgDeSoTxn, blockHashHex string, params
 			// Additionally, we need to check if this post is a repost and
 			// fetch the original poster
 			if repostedPostHash, isRepost := extraData[lib.RepostedPostHash]; isRepost {
-				repostedBlockHash := &lib.BlockHash{}
-				copy(repostedBlockHash[:], repostedPostHash)
-				// TODO: How to get this
+				txnMeta.SubmitPostTxindexMetadata.ParentPostHashHex = hex.EncodeToString(repostedPostHash)
 				repostPost := stateChangeMetadata.RepostPostEntry
 				if repostPost != nil {
 					txnMeta.AffectedPublicKeys = append(txnMeta.AffectedPublicKeys, &lib.AffectedPublicKey{


### PR DESCRIPTION
`SubmitPostTxindexMetadata.ParentPostHashHex` is currently used to store the `ParentPostHashHex` for comments. Here, I reuse that field for reposts and quote reposts. IMO this is a good use of the existing field.

We can still differentiate between comments and reposts/quote reposts by using the AffectedPublicKey.Metadata. For comments it is: `ParentPosterPublicKeyBase58Check`. For reposts and quote reposts it is: `RepostedPublicKeyBase58Check`.